### PR TITLE
Feat/auth

### DIFF
--- a/puncto-back/package.json
+++ b/puncto-back/package.json
@@ -1,7 +1,9 @@
 {
   "devDependencies": {
+    "@types/bcrypt": "^5.0.0",
     "@types/express": "^4.17.12",
     "@types/jest": "^26.0.23",
+    "@types/jsonwebtoken": "^8.5.1",
     "@types/node": "^15.6.1",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
@@ -26,8 +28,10 @@
     "format": "eslint src/**/*.ts --fix"
   },
   "dependencies": {
+    "bcrypt": "^5.0.1",
     "express": "^4.17.1",
     "inversify": "^5.1.1",
+    "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.6.9",
     "reflect-metadata": "^0.1.13",
     "typeorm": "^0.2.32"

--- a/puncto-back/src/api/user.ts
+++ b/puncto-back/src/api/user.ts
@@ -1,19 +1,48 @@
 import express from 'express'
 import { Request, Response } from 'express'
 import { UserDto } from '../dto/userDto';
+import { LoginDto } from '../dto/loginDto';
 import { UserService } from '../service/userService';
+import { AuthService } from '../service/authService';
 import { container } from '../inversify.config';
 
 const router = express.Router()
 
+// @TODO validar payload
+// @TODO validar email unico antes de cadastrar
+// @TODO validacao de erros
 router.post('/signup', async (req: Request, res: Response) => {
     try {
         const user = req.body as UserDto
         const userService = container.get(UserService)
         await userService.createUser(user)
-        res.status(200).json("Fon")
-    } catch (exception) {
+        res.status(201).json("Created")
+    } catch (err) {
+        console.log('Error signing up: ', err);
+    }
+})
 
+router.post('/login', async (req: Request, res: Response) => {
+    try {
+        const credentials = req.body as LoginDto
+
+        const userService = container.get(UserService)
+        const authService = container.get(AuthService)
+        const user = await userService.findByEmail(credentials.email);
+
+        const authToken = await authService.authenticate(credentials, user.password);
+
+        // @TODO handle this more nicely
+        if (!authToken) {
+            res.status(401).json('Invalid Credentials')
+        }
+
+        res.status(200).json({
+            authToken
+        })
+    } catch (err) {
+        console.log('Error signing up: ', err);
+        res.status(500);
     }
 })
 

--- a/puncto-back/src/api/user.ts
+++ b/puncto-back/src/api/user.ts
@@ -6,7 +6,7 @@ import { container } from '../inversify.config';
 
 const router = express.Router()
 
-router.post('/user', async (req: Request, res: Response) => {
+router.post('/signup', async (req: Request, res: Response) => {
     try {
         const user = req.body as UserDto
         const userService = container.get(UserService)

--- a/puncto-back/src/config.ts
+++ b/puncto-back/src/config.ts
@@ -1,0 +1,4 @@
+export const auth = {
+    secret: '0917B13A9091915D54B6336F45909539CCE452B3661B21F38641', // @TODO move to env variables
+    expires: '1h',
+  };

--- a/puncto-back/src/dto/loginDto.ts
+++ b/puncto-back/src/dto/loginDto.ts
@@ -1,0 +1,14 @@
+export interface ILoginProps {
+    email: string;
+    password: string;
+}
+
+export class LoginDto {
+    email: string;
+    password: string;
+
+    public constructor(props: ILoginProps) {
+        this.email = props.email;
+        this.password = props.password;
+    }
+}

--- a/puncto-back/src/dto/userDto.ts
+++ b/puncto-back/src/dto/userDto.ts
@@ -1,11 +1,20 @@
+export interface IUserProps {
+    firstName: string;
+    lastName: string;
+    email: string;
+    password: string;
+}
+
 export class UserDto {
     firstName: string;
     lastName: string;
-    age: number;
+    email: string;
+    password: string;
 
-    public constructor(firstName: string, lastName: string, age: number) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.age = age;
+    public constructor(props: IUserProps) {
+        this.firstName = props.firstName;
+        this.lastName = props.lastName;
+        this.email = props.email;
+        this.password = props.password;
     }
 }

--- a/puncto-back/src/entity/User.ts
+++ b/puncto-back/src/entity/User.ts
@@ -13,6 +13,9 @@ export class User extends BaseEntity {
     lastName: string;
 
     @Column()
-    age: number;
+    email: string;
+
+    @Column()
+    password: string;
 
 }

--- a/puncto-back/src/entity/User.ts
+++ b/puncto-back/src/entity/User.ts
@@ -1,4 +1,5 @@
-import { Entity, ObjectIdColumn, Column, BaseEntity } from "typeorm";
+import { Entity, ObjectIdColumn, Column, BaseEntity, BeforeUpdate, BeforeInsert } from "typeorm";
+import bcrypt from "bcrypt";
 
 @Entity()
 export class User extends BaseEntity {
@@ -17,5 +18,14 @@ export class User extends BaseEntity {
 
     @Column()
     password: string;
+
+    @BeforeInsert()
+    @BeforeUpdate()
+    hashPassword(): void {
+        if (this.password) {
+          const salt = bcrypt.genSaltSync(10);
+          this.password = bcrypt.hashSync(this.password, salt);
+        }
+      }
 
 }

--- a/puncto-back/src/inversify.config.ts
+++ b/puncto-back/src/inversify.config.ts
@@ -1,9 +1,11 @@
 import { Container } from "inversify";
 import { UserRepository } from "./repository/userRepository";
 import { UserService } from "./service/userService";
+import { AuthService } from "./service/authService";
 
 const container = new Container();
 container.bind<UserService>(UserService).to(UserService)
+container.bind<AuthService>(AuthService).to(AuthService)
 container.bind<UserRepository>(UserRepository).to(UserRepository)
 
 export { container };

--- a/puncto-back/src/repository/userRepository.ts
+++ b/puncto-back/src/repository/userRepository.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import { Connection, getConnection, Repository } from "typeorm";
-import { UserDto } from "../dto/userDto";
-import { User } from '../entity/user';
+import { UserDto, IUserProps } from "../dto/userDto";
+import { User } from '../entity/User';
 import { injectable } from "inversify";
 
 @injectable()
@@ -11,12 +11,14 @@ export class UserRepository {
     return connection.getRepository(User);
   }
 
-  async createUser(firstName: string, lastName: string, age: number): Promise<void> {
+  async createUser(props: IUserProps): Promise<void> {
     const repository = this.getUserRepository();
     const user = new User();
-    user.firstName = firstName;
-    user.lastName = lastName;
-    user.age = age;
+    user.firstName = props.firstName;
+    user.lastName = props.lastName;
+    user.email = props.email;
+    user.password = props.password;
+
     await repository.save(user);
   }
 

--- a/puncto-back/src/repository/userRepository.ts
+++ b/puncto-back/src/repository/userRepository.ts
@@ -28,6 +28,13 @@ export class UserRepository {
     console.log(allUsers)
     return allUsers
   }
+
+  async findByEmail(email: string): Promise<UserDto> {
+    const repository = this.getUserRepository();
+
+    const user = await repository.findOne({ where: { email } }) as UserDto;
+    return user
+  }
 }
 
 

--- a/puncto-back/src/service/authService.ts
+++ b/puncto-back/src/service/authService.ts
@@ -1,0 +1,20 @@
+import "reflect-metadata";
+
+import { injectable } from "inversify";
+import bcrypt from "bcrypt";
+import jwt from "jsonwebtoken";
+
+import { LoginDto } from "../dto/loginDto";
+import { auth } from "../config";
+
+@injectable()
+export class AuthService {
+    async authenticate(credentials: LoginDto, passwordHash: string): Promise<string> {
+        const verified = bcrypt.compareSync(credentials.password, passwordHash);
+        if (verified) {
+            return jwt.sign({ userEmail: credentials.email }, auth.secret, { expiresIn: '7d' });
+        }
+        return '';
+    }
+}
+

--- a/puncto-back/src/service/userService.test.ts
+++ b/puncto-back/src/service/userService.test.ts
@@ -1,4 +1,4 @@
-import { UserDto } from "../dto/userDto";
+import { UserDto, IUserProps } from "../dto/userDto";
 import { UserRepository } from "../repository/userRepository";
 import { UserService } from "./userService";
 import { container } from '../inversify.config';
@@ -8,30 +8,50 @@ describe("User service", () => {
     let mockAllUsers: UserDto[]
     const mockUserRepository: UserRepository = container.get(UserRepository);
 
-    const getUser = (firstName: string, lastName: string, age: number): UserDto => {
-        return new UserDto(firstName, lastName, age)
+    const getUser = (props: IUserProps): UserDto => {
+        return new UserDto(props)
     }
 
     beforeAll(() => {
         userService = new UserService(mockUserRepository)
-        mockAllUsers = [getUser("Gabriel", "Chaves", 20), getUser("Nome", "Sobrenome", 25)]
+        mockAllUsers = [getUser({
+            firstName: "Gabriel",
+            lastName: "Chaves",
+            email: "gabrielchaves@gmail.com",
+            password: "123456",
+        }), getUser({
+            firstName: "Philipe",
+            lastName: "Atela",
+            email: "philipe@gmail.com",
+            password: "123456",
+        })]
     })
 
 
     it("createUser should call userRepository.createUser", () => {
-        let spyUserRepository = jest.spyOn(mockUserRepository, 'createUser');
-        userService.createUser(getUser("Gabriel", "Chaves", 20))
+        const spyUserRepository = jest.spyOn(mockUserRepository, 'createUser');
+        userService.createUser(getUser({
+            firstName: "Gabriel",
+            lastName: "Chaves",
+            email: "gabrielchaves@gmail.com",
+            password: "123456",
+        }))
         expect(spyUserRepository).toHaveBeenCalledTimes(1);
     });
 
     it("findAllUsers should call userRepository.findAllUsers", async () => {
-        let spyUserRepository = jest.spyOn(mockUserRepository, 'findAllUsers').mockImplementation((): Promise<Array<UserDto>> => {
+        const spyUserRepository = jest.spyOn(mockUserRepository, 'findAllUsers').mockImplementation((): Promise<Array<UserDto>> => {
             return Promise.resolve(mockAllUsers);
         });
 
-        let users = await userService.findAllUsers();
+        const users = await userService.findAllUsers();
         expect(spyUserRepository).toHaveBeenCalledTimes(1);
         expect(users).toHaveLength(2);
-        expect(users).toContainEqual(getUser("Gabriel", "Chaves", 20))
+        expect(users).toContainEqual(getUser({
+            firstName: "Gabriel",
+            lastName: "Chaves",
+            email: "gabrielchaves@gmail.com",
+            password: "123456",
+        }))
     });
 });

--- a/puncto-back/src/service/userService.ts
+++ b/puncto-back/src/service/userService.ts
@@ -18,6 +18,14 @@ export class UserService {
         await this._userRepositoy.createUser(user)
     }
 
+    async findByEmail(email: string): Promise<UserDto> {
+        const user = await this._userRepositoy.findByEmail(email);
+        if (!user) {
+            throw new Error('User not found'); 
+        }
+        return user;
+    }
+
     async findAllUsers(): Promise<Array<UserDto>> {
         const allUsers = await this._userRepositoy.findAllUsers();
         return allUsers;

--- a/puncto-back/src/service/userService.ts
+++ b/puncto-back/src/service/userService.ts
@@ -15,7 +15,7 @@ export class UserService {
 
 
     async createUser(user: UserDto): Promise<void> {
-        await this._userRepositoy.createUser(user.firstName, user.lastName, user.age)
+        await this._userRepositoy.createUser(user)
     }
 
     async findAllUsers(): Promise<Array<UserDto>> {


### PR DESCRIPTION
- Adicionado campos email e senha no Usuario
- Refactor na forma como o DTO funciona, para receber um objeto com os parametros ao inves de ter varios parametros no construtor.
- Adicionado endpoints para signup e login

A API deve receber email e senha e retornar um token JWT, que deverá ser enviado pelo front-end em todas as requests autenticadas no header `Bearer <token>` para que a API consiga identificar as chamadas facilmente.

Falta um bocado de coisa, mas decidi ja abrir o PR porque ja da pra usar os endpoints de signup e login.