### PR TITLE
Feat/auth middleware

### DIFF
--- a/puncto-back/jest.config.js
+++ b/puncto-back/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  "testMatch": [
+    "**/?(*.)+(spec|test).js?(x)",
+  ],
 };

--- a/puncto-back/jest.config.js
+++ b/puncto-back/jest.config.js
@@ -1,7 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  "testMatch": [
-    "**/?(*.)+(spec|test).js?(x)",
-  ],
 };

--- a/puncto-back/package.json
+++ b/puncto-back/package.json
@@ -33,6 +33,7 @@
     "class-validator": "^0.13.1",
     "express": "^4.17.1",
     "inversify": "^5.1.1",
+    "json-typescript-mapper": "^1.1.3",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.6.9",
     "reflect-metadata": "^0.1.13",

--- a/puncto-back/package.json
+++ b/puncto-back/package.json
@@ -33,7 +33,6 @@
     "class-validator": "^0.13.1",
     "express": "^4.17.1",
     "inversify": "^5.1.1",
-    "json-typescript-mapper": "^1.1.3",
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.6.9",
     "reflect-metadata": "^0.1.13",

--- a/puncto-back/src/api/user.ts
+++ b/puncto-back/src/api/user.ts
@@ -7,13 +7,16 @@ import { LoginDto } from '../dto/loginDto';
 import { UserService } from '../service/userService';
 import { AuthService } from '../service/authService';
 import { container } from '../inversify.config';
-import { validate, validationError } from '../validation';
+import { validate, validationError } from '../middlewares/validation';
+import { authMiddleware } from '../middlewares/authentication';
 
 const log: Logger = new Logger();
 
 const router = express.Router();
 const authService = container.get(AuthService);
 const userService = container.get(UserService);
+
+router.use('/user', authMiddleware)
 
 // @TODO validar email unico antes de cadastrar
 router.post('/signup', validate(UserDto), async (req: Request, res: Response) => {
@@ -46,12 +49,14 @@ router.post('/login', validate(LoginDto), async (req: Request, res: Response) =>
       authToken,
     });
   } catch (err) {
-    log.warn('Error logging in up: ', err);
+    log.warn('Error logging in: ', err);
     res.status(err.statusCode).json(err.message);
   }
 });
 
 router.get('/user', async (req: Request, res: Response) => {
+  console.log('Fetching users for email: ', req.userEmail);
+
   try {
     const allUsers = await userService.findAllUsers();
     res.status(200).json(allUsers);

--- a/puncto-back/src/config.ts
+++ b/puncto-back/src/config.ts
@@ -2,7 +2,7 @@ import { ConnectionOptions } from 'typeorm';
 
 export const auth = {
   secret: '0917B13A9091915D54B6336F45909539CCE452B3661B21F38641', // @TODO move to env variables
-  expires: '1h',
+  expires: '7d',
 };
 
 export const connectionOptions: ConnectionOptions = {

--- a/puncto-back/src/index.ts
+++ b/puncto-back/src/index.ts
@@ -1,9 +1,21 @@
 import { createConnection } from 'typeorm';
+
 import userRouter from './api/user';
 import companyRouter from './api/company';
 import { connectionOptions } from './config';
 
 const express = require('express');
+
+// meio gambiarra isso, mas não achei outra forma facil
+// de permitir injetar outros valores na request
+declare global {
+  namespace Express {
+    interface Request {
+      userEmail: string
+    }
+  }
+}
+
 const app = express();
 const port = 3000;
 

--- a/puncto-back/src/middlewares/authentication.ts
+++ b/puncto-back/src/middlewares/authentication.ts
@@ -1,0 +1,25 @@
+import { Request } from 'express';
+
+import { AuthInfo, AuthService } from '../service/authService'
+import { container } from '../inversify.config';
+
+const authService = container.get(AuthService);
+
+// esse middleware decodifica o JWT recebido no header da requisicao e injeta
+// o email do usuario no objeto Request
+export const authMiddleware = (req: Request, res, next) => {
+  if (!req.headers.authorization) {
+    res.status(401).json('Missing authentication token');
+  }
+
+  // From `Bearer <token>` to `<token>`
+  const bearerToken = req.headers.authorization?.split(' ')[1] || '';
+
+  try {
+    const authInfo: AuthInfo = authService.verifyToken(bearerToken);
+    req.userEmail = authInfo.userEmail;
+    next()
+  } catch(error) {
+    res.status(401).json('Invalid authentication token');
+  }
+}

--- a/puncto-back/src/middlewares/validation.ts
+++ b/puncto-back/src/middlewares/validation.ts
@@ -1,6 +1,6 @@
 import * as express from 'express';
-import {Validator, ValidationError} from "class-validator";
-import {plainToClass} from 'class-transformer';
+import { Validator, ValidationError } from "class-validator";
+import { plainToClass } from 'class-transformer';
 
 type Constructor<T> = {new(): T};
 

--- a/puncto-back/src/service/authService.ts
+++ b/puncto-back/src/service/authService.ts
@@ -8,6 +8,12 @@ import { LoginDto } from '../dto/loginDto';
 import { auth } from '../config';
 import { UnauthorizedException } from '../exceptions/UnauthorizedException';
 
+export type AuthInfo = {
+  userEmail: string;
+  iat: number;
+  exp: number;
+}
+
 @injectable()
 export class AuthService {
   authenticate(credentials: LoginDto, passwordHash: string): void {
@@ -19,6 +25,15 @@ export class AuthService {
   }
 
   generateToken(email: string): string {
-    return jwt.sign({ userEmail: email }, auth.secret, { expiresIn: '7d' });
+    const token = jwt.sign({ userEmail: email }, auth.secret, { expiresIn: auth.expires });
+    return token;
+  }
+
+  verifyToken(jwtToken: string): AuthInfo {
+    try {
+      return jwt.verify(jwtToken, auth.secret) as AuthInfo;
+    } catch (error) {
+      throw new UnauthorizedException('Invalid auth token');
+    }
   }
 }


### PR DESCRIPTION
Adicionado um middleware que intercepta as requisicoes recebidas, decodifica o token de autenticacao e injeta o email do usuário dono do token no objeto `Request` do express.

Assim, todas as rotas que usam o middleware tem facil acesso ao email do usuário que está fazendo a requisicão, facilitando que sejam feitas as queries no banco para buscar apenas os dados que pertencem a aquele email.